### PR TITLE
Added "String pluginName" parameter to display function

### DIFF
--- a/src/main/java/net/milkbowl/vault2/economy/Economy.java
+++ b/src/main/java/net/milkbowl/vault2/economy/Economy.java
@@ -73,34 +73,37 @@ public interface Economy {
      * function returns the number of digits the plugin keeps or -1 if no rounding
      * occurs.
      * 
+     * @param pluginName The name of the plugin that is calling the method.
      * @return number of digits after the decimal point this plugin supports or -1
      *         if no rounding occurs.
      */
     @NotNull
-    int fractionalDigits();
+    int fractionalDigits(final String pluginName);
 
     /**
      * Plugins use this method to format a given BigDecimal amount into a human-readable
      * amount using your economy plugin's currency names/conventions.
      *
+     * @param pluginName The name of the plugin that is calling the method.
      * @param amount to format.
      *
      * @return Human-readable string describing amount, ie 5 Dollars or 5.55 Pounds.
      */
     @NotNull
-    String format(BigDecimal amount);
+    String format(final String pluginName, BigDecimal amount);
 
     /**
      * Plugins use this method to format a given BigDecimal amount into a human-readable
      * amount using your economy plugin's currency names/conventions.
      *
+     * @param pluginName The name of the plugin that is calling the method.
      * @param amount to format.
      * @param currency the currency to use for the format.
      *
      * @return Human-readable string describing amount, ie 5 Dollars or 5.55 Pounds.
      */
     @NotNull
-    String format(BigDecimal amount, final String currency);
+    String format(final String pluginName, BigDecimal amount, final String currency);
 
     /**
      * Returns true if a currency with the specified name exists.
@@ -114,30 +117,34 @@ public interface Economy {
     /**
      * Used to get the default currency. This could be the default currency for the server globally or
      * for the default world if the implementation supports multi-world.
+     *
+     * @param pluginName The name of the plugin that is calling the method.
      * @return The currency that is the default for the server if multi-world support is not available
      * otherwise the default for the default world.
      *
      */
     @NotNull
-    String getDefaultCurrency();
+    String getDefaultCurrency(final String pluginName);
 
     /**
      * Returns the name of the default currency in plural form. If the economy being used
      * does not support currency names then an empty string will be returned.
      *
+     * @param pluginName The name of the plugin that is calling the method.
      * @return name of the currency (plural) ie: Dollars or Pounds.
      */
     @NotNull
-    String defaultCurrencyNamePlural();
+    String defaultCurrencyNamePlural(final String pluginName);
 
     /**
      * Returns the name of the default currency in singular form. If the economy being used
      * does not support currency names then an empty string will be returned.
      * 
+     * @param pluginName The name of the plugin that is calling the method.
      * @return name of the currency (singular) ie: Dollar or Pound.
      */
     @NotNull
-    String defaultCurrencyNameSingular();
+    String defaultCurrencyNameSingular(final String pluginName);
 
     /**
      * Returns a list of currencies used by the economy plugin. These are able to be used


### PR DESCRIPTION
I added the "String pluginName" parameter to the function: fractionalDigits, format, getDefaultCurrency, defaultCurrencyNamePlural and defaultCurrencyNameSingular for the creation of an economy plugin that redirects the calls of these functions to different currencies depending on the plugin that calls them

(for example in my multi-currency economy plugin I created a possibility to define a currency on a plugin the modifications I made allow these plugins to display the amounts in the right currency (in case the calling plugin does not support multi-currency))