### PR TITLE
Update repository URLs, and CI workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,49 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+  pull_request:
+    branches:
+      - master
+      - main
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: VaultUnlockedAPI
+          path: |
+            **/build/libs/*.jar

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -11,12 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # if you have a protection rule on your repository, you'll need to give write permission to the workflow.
+
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Deploy JavaDoc 🚀
         uses: MathieuSoysal/Javadoc-publisher.yml@v3.0.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: gh-pages
-          java-version: 8
+          java-version: 21
           target-folder: javadoc # url will be https://<username>.github.io/<repo>/javadoc, This can be left as nothing to generate javadocs in the root folder.
-          project: maven
+          project: gradle

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ How to include the API with Maven:
 ```xml
 <repositories>
     <repository>
-        <id>codemc-repo</id>
-        <url>https://repo.codemc.org/repository/maven-public</url>
+        <id>codemc-creatorfromhell</id>
+        <url>https://repo.codemc.io/repository/creatorfromhell/</url>
     </repository>
 </repositories>
 
@@ -14,7 +14,7 @@ How to include the API with Maven:
     <dependency>
         <groupId>net.milkbowl.vault</groupId>
         <artifactId>VaultUnlockedAPI</artifactId>
-        <version>2.11</version><!-- Validate this is the most recent version from the CI -->
+        <version>2.15</version><!-- Validate this is the most recent version from the CI -->
         <scope>provided</scope>
     </dependency>
 </dependencies>
@@ -23,10 +23,10 @@ How to include the API with Maven:
 How to include the API with Gradle:
 ```groovy
 repositories {
-    maven { url 'https://repo.codemc.org/repository/maven-public' }
+    maven { url 'https://repo.codemc.io/repository/creatorfromhell/' }
 }
 dependencies {
-    compileOnly "net.milkbowl.vault:VaultUnlockedAPI:2.11"
+    compileOnly "net.milkbowl.vault:VaultUnlockedAPI:2.15"
 }
 ```
 


### PR DESCRIPTION
Updated repository URLs and dependency versions in README.md for consistency and updated the Javadoc workflow to use Gradle instead of Maven. Added a new Gradle CI workflow for building the project and uploading artifacts.